### PR TITLE
Rails 3.0 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+[2012-02-22]
+
+* Add support for Rails 3.0 [Kornelius Kalnbach]
+
 [5 March 2009]
 
 * Add support for I18N [Roman Shterenzon]

--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,12 @@ This fork is patched to work with Rails 3.0.
 
 Install
 =======
-    gem "validates_date_time", "~> 1.0.0", :git => "git://github.com/sofatutor/validates_date_time", :branch => 'rails-3'
+
+Put this in your Gemfile:
+
+```ruby
+gem "validates_date_time", :git => "git://github.com/sofatutor/validates_date_time", :branch => 'rails-3'
+```
 
 Instructions
 ============

--- a/README.markdown
+++ b/README.markdown
@@ -2,9 +2,11 @@ validates_date_time
 ===================
 This plugin adds the ability to do stricter date and time checking with ActiveRecord.
 
+This fork is patched to work with Rails 3.0.
+
 Install
 =======
-    ./script/plugin install git://github.com/nickstenning/validates_date_time.git
+    gem "validates_date_time", "~> 1.0.0", :git => "git://github.com/sofatutor/validates_date_time", :branch => 'rails-3'
 
 Instructions
 ============

--- a/lib/validates_date_time.rb
+++ b/lib/validates_date_time.rb
@@ -14,8 +14,7 @@ module ValidatesDateTime
 
   DEFAULT_TEMPORAL_VALIDATION_OPTIONS = {
     :before_message => "must be before %s",
-    :after_message  => "must be after %s",
-    :on => :save
+    :after_message  => "must be after %s"
   }.freeze
 
   class ValidatesDateTimeRestriction < Struct.new(:raw_value, :parse_method)
@@ -114,7 +113,7 @@ module ValidatesDateTime
       if options[:before]
         options[:before].each do |r|
           if r.value(record) and value >= r.last_value
-            record.errors.add(attr_name, :before, :value => r, :default => options[:before_message] % r)
+            record.errors.add(attr_name, :before, :value => r, :message => options[:before_message] % r)
             break
           end
         end
@@ -123,7 +122,7 @@ module ValidatesDateTime
       if options[:after]
         options[:after].each do |r|
           if r.value(record) and value <= r.last_value
-            record.errors.add(attr_name, :after, :value => r, :default => options[:after_message] % r)
+            record.errors.add(attr_name, :after, :value => r, :message => options[:after_message] % r)
             break
           end
         end


### PR DESCRIPTION
We wanted to keep using validates_date_time when we updated to Rails 3, so we forked and patched it.

Tested with Rails 3.0.11.
